### PR TITLE
Allow MaybeUninit in input and output of inline assembly

### DIFF
--- a/src/inline_asm.rs
+++ b/src/inline_asm.rs
@@ -785,9 +785,9 @@ fn call_inline_asm<'tcx>(
     for (offset, place) in outputs {
         let ty = if place.layout().ty.is_simd() {
             let (lane_count, lane_type) = place.layout().ty.simd_size_and_type(fx.tcx);
-            fx.clif_type(lane_type).unwrap().by(lane_count.try_into().unwrap()).unwrap()
+            asm_clif_type(fx, lane_type).unwrap().by(lane_count.try_into().unwrap()).unwrap()
         } else {
-            fx.clif_type(place.layout().ty).unwrap()
+            asm_clif_type(fx, place.layout().ty).unwrap()
         };
         let value = stack_slot.offset(fx, i32::try_from(offset.bytes()).unwrap().into()).load(
             fx,
@@ -795,5 +795,26 @@ fn call_inline_asm<'tcx>(
             MemFlags::trusted(),
         );
         place.write_cvalue(fx, CValue::by_val(value, place.layout()));
+    }
+}
+
+fn asm_clif_type<'tcx>(fx: &FunctionCx<'_, '_, 'tcx>, ty: Ty<'tcx>) -> Option<types::Type> {
+    match ty.kind() {
+        // Adapted from https://github.com/rust-lang/rust/blob/f3c66088610c1b80110297c2d9a8b5f9265b013f/compiler/rustc_hir_analysis/src/check/intrinsicck.rs#L136-L151
+        ty::Adt(adt, args) if Some(adt.did()) == fx.tcx.lang_items().maybe_uninit() => {
+            let fields = &adt.non_enum_variant().fields;
+            let ty = fields[FieldIdx::from_u32(1)].ty(fx.tcx, args);
+            let ty::Adt(ty, args) = ty.kind() else {
+                unreachable!("expected first field of `MaybeUninit` to be an ADT")
+            };
+            assert!(
+                ty.is_manually_drop(),
+                "expected first field of `MaybeUninit` to be `ManuallyDrop`"
+            );
+            let fields = &ty.non_enum_variant().fields;
+            let ty = fields[FieldIdx::ZERO].ty(fx.tcx, args);
+            fx.clif_type(ty)
+        }
+        _ => fx.clif_type(ty),
     }
 }


### PR DESCRIPTION
Fixes #1428

MaybeUninit registers have been supported since https://github.com/rust-lang/rust/pull/114790.
This PR uses the same way as that used in that PR.

Tested on a crate with heavy use of MaybeUninit registers (https://github.com/taiki-e/atomic-maybe-uninit).

```console
$ git clone https://github.com/taiki-e/atomic-maybe-uninit
$ cd atomic-maybe-uninit

# With `-Z codegen-backend=cranelift`
$ RUSTFLAGS='-Z codegen-backend=cranelift' ./tools/test.sh --tests 
+ RUSTFLAGS='-Z codegen-backend=cranelift -C panic=abort -Z panic_abort_tests' \
+ RUSTDOCFLAGS=' -C panic=abort -Z panic_abort_tests' \
+ cargo test --tests --all-features --workspace
   Compiling atomic-maybe-uninit v0.3.1 (/Users/taiki/projects/sources/taiki-e/atomic-maybe-uninit)
thread 'rustc' panicked at src/inline_asm.rs:790:45:
called `Option::unwrap()` on a `None` value

# With this PR
$ cargo=path/to/dist/cargo-clif ./tools/test.sh --tests
+ RUSTFLAGS=' -C panic=abort -Z panic_abort_tests' \
+ RUSTDOCFLAGS=' -C panic=abort -Z panic_abort_tests' \
+ path/to/dist/cargo-clif test --tests --all-features --workspace
   Compiling atomic-maybe-uninit v0.3.1 (/Users/taiki/projects/sources/taiki-e/atomic-maybe-uninit)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running unittests src/lib.rs (target/debug/deps/atomic_maybe_uninit-299d38e254d4f4b0)

running 192 tests
<omitted>
test result: ok. 192 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.39s
```