### PR TITLE
Translate MIR to clif ir in parallel with parallel rustc

### DIFF
--- a/src/concurrency_limiter.rs
+++ b/src/concurrency_limiter.rs
@@ -78,11 +78,6 @@ impl ConcurrencyLimiter {
         }
     }
 
-    pub(super) fn job_already_done(&mut self) {
-        let mut state = self.state.lock().unwrap();
-        state.job_already_done();
-    }
-
     pub(crate) fn finished(mut self) {
         self.helper_thread.take();
 
@@ -185,14 +180,6 @@ mod state {
             self.assert_invariants();
             self.pending_jobs -= 1;
             self.active_jobs -= 1;
-            self.assert_invariants();
-            self.drop_excess_capacity();
-            self.assert_invariants();
-        }
-
-        pub(super) fn job_already_done(&mut self) {
-            self.assert_invariants();
-            self.pending_jobs -= 1;
             self.assert_invariants();
             self.drop_excess_capacity();
             self.assert_invariants();


### PR DESCRIPTION
On dev-desktop the advantage of cg_clif over cg_llvm on simple-raytracer is 15% when parallel rustc is disabled. With -Zthreads=16 the advantage goes from 5% to 22% with this change.

Fixes https://github.com/rust-lang/rustc_codegen_cranelift/issues/1423