### PR TITLE
add `llvm.x86.sse2.cvtps2dq`

### DIFF
--- a/src/intrinsics/llvm_x86.rs
+++ b/src/intrinsics/llvm_x86.rs
@@ -459,11 +459,20 @@ pub(crate) fn codegen_x86_llvm_intrinsic_call<'tcx>(
             intrinsic_args!(fx, args => (a); intrinsic);
             let a = a.load_scalar(fx);
 
+            let value = fx.bcx.ins().x86_cvtt2dq(types::I32X4, a);
+            let cvalue = CValue::by_val(value, ret.layout());
+            ret.write_cvalue(fx, cvalue);
+        }
+        "llvm.x86.sse2.cvtps2dq" => {
+            // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtps_epi32
+            intrinsic_args!(fx, args => (a); intrinsic);
+            let a = a.load_scalar(fx);
+
             // Using inline asm instead of fcvt_to_sint_sat as unrepresentable values are turned
             // into 0x80000000 for which Cranelift doesn't have a native instruction.
             codegen_inline_asm_inner(
                 fx,
-                &[InlineAsmTemplatePiece::String(format!("cvttps2dq xmm0, xmm0"))],
+                &[InlineAsmTemplatePiece::String(format!("cvtps2dq xmm0, xmm0"))],
                 &[CInlineAsmOperand::InOut {
                     reg: InlineAsmRegOrRegClass::Reg(InlineAsmReg::X86(X86InlineAsmReg::xmm0)),
                     _late: true,


### PR DESCRIPTION
part of https://github.com/rust-lang/rustc_codegen_cranelift/issues/1492, but some further intrinsics are needed for the `tiny_skia` test suite to pass with cranelift:

```
warning: unsupported x86 llvm intrinsic llvm.x86.sse.rcp.ps; replacing with trap

warning: unsupported x86 llvm intrinsic llvm.x86.sse.rsqrt.ps; replacing with trap

warning: unsupported x86 llvm intrinsic llvm.x86.sse2.psll.d; replacing with trap

warning: unsupported x86 llvm intrinsic llvm.x86.sse2.psrl.d; replacing with trap
```

nonetheless, this addition makes 26 more tests pass