### PR TITLE
Revert run-make/const_fn_mir ignore

### DIFF
--- a/scripts/test_rustc_tests.sh
+++ b/scripts/test_rustc_tests.sh
@@ -127,7 +127,6 @@ rm -r tests/run-make/panic-abort-eh_frame # .eh_frame emitted with panic=abort
 # bugs in the test suite
 # ======================
 rm tests/ui/process/nofile-limit.rs # TODO some AArch64 linking issue
-rm -r tests/run-make/const_fn_mir # needs-unwind directive accidentally dropped
 
 rm tests/ui/stdio-is-blocking.rs # really slow with unoptimized libstd
 


### PR DESCRIPTION
This partially reverts commit e24117653571901c8e1a2212fb93dd0cc4401aaf.

Can be merged once https://github.com/rust-lang/rust/pull/126580 is merged.