### PR TITLE
Fix varargs support on `aarch64-apple-darwin`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,9 @@ jobs:
             env:
               TARGET_TRIPLE: aarch64-unknown-linux-gnu
             apt_deps: gcc-aarch64-linux-gnu qemu-user
+          - os: macos-latest
+            env:
+              TARGET_TRIPLE: aarch64-apple-darwin
           - os: ubuntu-latest
             env:
               TARGET_TRIPLE: s390x-unknown-linux-gnu
@@ -214,6 +217,9 @@ jobs:
           - os: macos-latest
             env:
               TARGET_TRIPLE: x86_64-apple-darwin
+          - os: macos-latest
+            env:
+              TARGET_TRIPLE: aarch64-apple-darwin
           # cross-compile from Linux to Windows using mingw
           - os: ubuntu-latest
             env:


### PR DESCRIPTION
Uses the strategy outlined in [#1451 (comment)](https://github.com/rust-lang/rustc_codegen_cranelift/issues/1451#issuecomment-2169248769) to enable support for varargs functions with integer/pointer arguments on `aarch64-apple-darwin`. CI testing is also added for `aarch64-apple-darwin`.