### PR TITLE
issue #1511: set rustup profile

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly-2024-07-13"
+profile = "minimal"
 components = ["rust-src", "rustc-dev", "llvm-tools"]


### PR DESCRIPTION
downloading toolchain without minimal profile: 54.323

<img width="874" alt="WithoutMinimal" src="https://github.com/user-attachments/assets/a3109467-91cd-450d-96a8-41e70f17e7ed">

downloading toolchain with minimal profile: 17.376

<img width="884" alt="Screenshot 2024-07-13 at 9 46 24 PM" src="https://github.com/user-attachments/assets/cb3f7ac4-7887-4d25-95b7-3003df60a80f">

issue #1511 
