### PR TITLE
Set rustup profile to minimal

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           sed -i 's/components.*/components = []/' rust-toolchain
-          echo 'profile = "minimal"' >> rust-toolchain
       - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,6 @@ jobs:
     - name: Avoid installing rustc-dev
       run: |
         sed -i 's/components.*/components = ["rustfmt"]/' rust-toolchain
-        echo 'profile = "minimal"' >> rust-toolchain
         rustfmt -v
 
     - name: Rustfmt

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly-2024-07-13"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
+profile = "minimal"


### PR DESCRIPTION
This PR fixes #1511 by setting the minimal profile in the toolchain file, and removing the explicit places where this was already done in CI scripts.

I don't think using `rustup set profile minimal` as you mention in the issue works when there's already a rustup override file: I believe the override kinda sets the profile back to its default value. 