### PR TITLE
Write return value for `ptr_mask` intrinsic

### DIFF
--- a/src/intrinsics/mod.rs
+++ b/src/intrinsics/mod.rs
@@ -600,9 +600,11 @@ fn codegen_regular_intrinsic_call<'tcx>(
 
         sym::ptr_mask => {
             intrinsic_args!(fx, args => (ptr, mask); intrinsic);
+            let ptr_layout = ptr.layout();
             let ptr = ptr.load_scalar(fx);
             let mask = mask.load_scalar(fx);
-            fx.bcx.ins().band(ptr, mask);
+            let res = fx.bcx.ins().band(ptr, mask);
+            ret.write_cvalue(fx, CValue::by_val(res, ptr_layout));
         }
 
         sym::write_bytes | sym::volatile_set_memory => {


### PR DESCRIPTION
This was forgotten. Without it, ptr_mask just always returns null.

Fixes https://github.com/rust-lang/rustc_codegen_cranelift/issues/1507
Fixes https://github.com/rust-lang/rustc_codegen_cranelift/issues/1535

I tested locally that this fixes both the ptr_mask doc tests and the original full minimization of https://github.com/rust-lang/rustc_codegen_cranelift/issues/1535 (involving the queue rwlock).