### PR TITLE
Use a BufWriter in emit_module to reduce syscall overhead

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,8 @@ impl CodegenBackend for CraneliftCodegenBackend {
         sess: &Session,
         outputs: &OutputFilenames,
     ) -> (CodegenResults, FxIndexMap<WorkProductId, WorkProduct>) {
+        let _timer = sess.timer("finish_ongoing_codegen");
+
         ongoing_codegen.downcast::<driver::aot::OngoingCodegen>().unwrap().join(
             sess,
             outputs,


### PR DESCRIPTION
For the coercions rustc-perf benchmark without this commit reduces the total amount of time it takes to emit the object file from 270ms to 27ms.