### PR TITLE
Disable clif ir verifier by default

### DIFF
--- a/src/driver/aot.rs
+++ b/src/driver/aot.rs
@@ -516,6 +516,7 @@ fn module_codegen(
                     MonoItem::Fn(inst) => {
                         if let Some(codegened_function) = crate::base::codegen_fn(
                             tcx,
+                            &backend_config,
                             &mut cx,
                             &mut type_dbg,
                             Function::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,8 @@ fn build_isa(sess: &Session, backend_config: &BackendConfig) -> Arc<dyn TargetIs
 
     let mut flags_builder = settings::builder();
     flags_builder.enable("is_pic").unwrap();
-    let enable_verifier = if backend_config.enable_verifier { "true" } else { "false" };
+    let enable_verifier =
+        if sess.verify_llvm_ir() || backend_config.enable_verifier { "true" } else { "false" };
     flags_builder.set("enable_verifier", enable_verifier).unwrap();
     flags_builder.set("regalloc_checker", enable_verifier).unwrap();
 


### PR DESCRIPTION
It's been a while since it last found something outside of development, yet it is rather expensive. It is still enabled by debug assertions are enabled for cg_clif or when -Z verify-llvm-ir=yes is passed.