### PR TITLE
hook up tracing to cg_cranelift

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ extern crate rustc_metadata;
 extern crate rustc_session;
 extern crate rustc_span;
 extern crate rustc_target;
+#[macro_use]
+extern crate tracing;
 
 // This prevents duplicating functions and statics that are already part of the host rustc process.
 #[allow(unused_extern_crates)]
@@ -208,6 +210,7 @@ impl CodegenBackend for CraneliftCodegenBackend {
         need_metadata_module: bool,
     ) -> Box<dyn Any> {
         tcx.dcx().abort_if_errors();
+        info!("codegen crate {}", tcx.crate_name(LOCAL_CRATE));
         let config = self.config.clone().unwrap_or_else(|| {
             BackendConfig::from_opts(&tcx.sess.opts.cg.llvm_args)
                 .unwrap_or_else(|err| tcx.sess.dcx().fatal(err))


### PR DESCRIPTION
this was easier than expected. here is an example of using RUSTC_LOG with a build of cranelift from rust-lang/rust:
```
$ RUSTC_LOG=rustc_codegen_cranelift cargo +stage1 b
   Compiling example v0.1.0 (/home/jyn/src/example)
 INFO rustc_codegen_cranelift codegen crate example
 INFO rustc_codegen_cranelift codegen crate example
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.44s
```