### PR TITLE
support `-Zmin-function-alignment`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,12 @@ fn build_isa(sess: &Session, jit: bool) -> Arc<dyn TargetIsa + 'static> {
 
     flags_builder.set("enable_llvm_abi_extensions", "true").unwrap();
 
+    if let Some(align) = sess.opts.unstable_opts.min_function_alignment {
+        flags_builder
+            .set("log2_min_function_alignment", &align.bytes().ilog2().to_string())
+            .unwrap();
+    }
+
     use rustc_session::config::OptLevel;
     match sess.opts.optimize {
         OptLevel::No => {


### PR DESCRIPTION
fixes https://github.com/rust-lang/rustc_codegen_cranelift/issues/1555

Based on the timing, this should be supported now 

- https://github.com/bytecodealliance/wasmtime/pull/10391 was merged on March 13th
- https://crates.io/crates/cranelift was last released on March 20th

I strongly suspect that no tests will hit this though (though I don't see how the relevant tests are ignored in `scripts/test_rustc_tests.sh`). As far as I can tell, function alignment with `#[repr(align(N))]` is not yet supported. I vaguely rember we discussed how this could be added, but now I can't find a way in the cranelift docs to align an individual function.