### PR TITLE
Enable `[no-mentions]` and `[issue-links]` in `rustbot`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,7 @@
+# Documentation at https://forge.rust-lang.org/triagebot/index.html
+
+# Prevents un-canonicalized issue links (to avoid wrong issues being linked in r-l/rust)
+[issue-links]
+
+# Prevents mentions in commits to avoid users being spammed
+[no-mentions]


### PR DESCRIPTION
This PR enables [`[no-mentions]`](https://forge.rust-lang.org/triagebot/no-mentions.html) and [`[issue-links]`](https://forge.rust-lang.org/triagebot/issue-links.html) from rustbot in `triagebot.toml`.

Context at https://github.com/rust-lang/team/pull/1790