### PR TITLE
Update availability of Cranelift

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ If not please open an issue.
 
 ## Download using Rustup
 
-The Cranelift codegen backend is distributed in nightly builds on Linux and x86_64 macOS. If you want to
+The Cranelift codegen backend is distributed in nightly builds on Linux, macOS and x86_64 Windows. If you want to
 install it using Rustup, you can do that by running:
 
 ```bash
@@ -79,7 +79,7 @@ For more docs on how to build and test see [build_system/usage.txt](build_system
 Not all targets are available as rustup component for nightly. See notes in the platform support matrix.
 
 [^xcoff]: XCOFF object file format is not supported.
-[^no-rustup]: Not available as rustup component for nightly. You can build it yourself.
+[^no-rustup]: Not available as [rustup component for nightly](https://rust-lang.github.io/rustup-components-history/). You can build it yourself.
 
 ## Usage
 


### PR DESCRIPTION
Cranelift also ships on Windows these days. This updates the Readme to point that out.

https://rust-lang.github.io/rustup-components-history seems to be an up-to-date source for where Cranelift is available. It seems to be available for both Tier 1 macOS variants, so I changed `x86_64 macOS` to `macOS`

Also, I noticed that the install instructions still say `rustc-codegen-cranelift-preview`, while name name seems to have changed to `rustc-codegen-cranelift`?
