### PR TITLE
Support -Zembed-source in debuginfo

### DIFF
--- a/scripts/test_rustc_tests.sh
+++ b/scripts/test_rustc_tests.sh
@@ -60,7 +60,6 @@ rm tests/ui/asm/global-asm-mono-sym-fn.rs # same
 rm tests/ui/asm/naked-asm-mono-sym-fn.rs # same
 rm tests/ui/asm/x86_64/goto.rs # inline asm labels not supported
 rm tests/ui/simd/simd-bitmask-notpow2.rs # non-pow-of-2 simd vector sizes
-rm -r tests/run-make/embed-source-dwarf # embedding sources in debuginfo
 rm -r tests/run-make/used-proc-macro # used(linker) isn't supported yet
 rm tests/ui/linking/no-gc-encapsulation-symbols.rs # same
 rm tests/ui/attributes/fn-align-dyn.rs # per-function alignment not supported


### PR DESCRIPTION
Fixes rust-lang/rustc_codegen_cranelift#1528 

- honour the session DWARF version, enabling v5 when embed-source is requested and plumb the flag through the debug context
- attach embedded source bytes to line table FileInfo records alongside existing MD5 hashes
- stop excluding rustc’s embed-source-dwarf run-make test so CG_CLIF exercises the feature