### PR TITLE
Update `rustup.sh` to use `rustc-josh-sync`

### DIFF
--- a/scripts/rustup.sh
+++ b/scripts/rustup.sh
@@ -4,20 +4,6 @@ set -e
 
 TOOLCHAIN=${TOOLCHAIN:-$(date +%Y-%m-%d)}
 
-function check_git_fixed_subtree() {
-    if [[ ! -e ./git-fixed-subtree.sh ]]; then
-        echo "Missing git-fixed-subtree.sh. Please run the following commands to download it:"
-        echo "curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/bjorn3/git/tqc-subtree-portable/contrib/subtree/git-subtree.sh -o git-fixed-subtree.sh"
-        echo "chmod u+x git-fixed-subtree.sh"
-        exit 1
-    fi
-    if [[ ! -x ./git-fixed-subtree.sh ]]; then
-        echo "git-fixed-subtree.sh is not executable. Please run the following command to make it executable:"
-        echo "chmod u+x git-fixed-subtree.sh"
-        exit 1
-    fi
-}
-
 case $1 in
     "prepare")
         echo "=> Installing new nightly"
@@ -38,39 +24,19 @@ case $1 in
         git commit -m "Rustup to $(rustc -V)"
         ;;
     "push")
-        check_git_fixed_subtree
-
-        cg_clif=$(pwd)
-        pushd ../rust
-        git pull origin main
         branch=sync_cg_clif-$(date +%Y-%m-%d)
-        git checkout -b "$branch"
-        "$cg_clif/git-fixed-subtree.sh" pull --prefix=compiler/rustc_codegen_cranelift/ https://github.com/rust-lang/rustc_codegen_cranelift.git main
-        git push -u my "$branch"
-
-        # immediately merge the merge commit into cg_clif to prevent merge conflicts when syncing
-        # from rust-lang/rust later
-        "$cg_clif/git-fixed-subtree.sh" push --prefix=compiler/rustc_codegen_cranelift/ "$cg_clif" sync_from_rust
-        popd
-        git merge sync_from_rust
+        rustc-josh-sync push "${branch}" bjorn3
 	;;
     "pull")
-        check_git_fixed_subtree
-
         RUST_VERS=$(curl "https://static.rust-lang.org/dist/$TOOLCHAIN/channel-rust-nightly-git-commit-hash.txt")
         echo "Pulling $RUST_VERS ($TOOLCHAIN)"
 
-        cg_clif=$(pwd)
-        pushd ../rust
-        git fetch origin main
-        git -c advice.detachedHead=false checkout "$RUST_VERS"
-        "$cg_clif/git-fixed-subtree.sh" push --prefix=compiler/rustc_codegen_cranelift/ "$cg_clif" sync_from_rust
-        popd
-        git merge sync_from_rust -m "Sync from rust $RUST_VERS"
-        git branch -d sync_from_rust
+        branch=rustc-pull-$(date +%Y-%m-%d)
+        git checkout -b "${branch}"
+        rustc-josh-sync pull --upstream-commit "${RUST_VERS}"
         ;;
     *)
         echo "Unknown command '$1'"
-        echo "Usage: ./rustup.sh prepare|commit"
+        echo "Usage: ./rustup.sh prepare|commit|push|pull"
         ;;
 esac


### PR DESCRIPTION
Depends on https://github.com/rust-lang/rustc_codegen_cranelift/pull/1617 (that should be merged first).
