### PR TITLE
Implement sym operand support for global_asm!

### DIFF
--- a/src/driver/aot.rs
+++ b/src/driver/aot.rs
@@ -518,6 +518,8 @@ fn codegen_cgu_content(
 
     let mut debug_context = DebugContext::new(tcx, module.isa(), false, cgu_name.as_str());
     let mut global_asm = String::new();
+    let mut global_asm_sym_index = 0u32;
+    let target_config = module.target_config();
     let mut type_dbg = TypeDebugContext::default();
     super::predefine_mono_items(tcx, module, &mono_items);
     let mut codegened_functions = vec![];
@@ -527,7 +529,13 @@ fn codegen_cgu_content(
                 let flags = tcx.codegen_instance_attrs(instance.def).flags;
                 if flags.contains(CodegenFnAttrFlags::NAKED) {
                     rustc_codegen_ssa::mir::naked_asm::codegen_naked_asm(
-                        &mut GlobalAsmContext { tcx, global_asm: &mut global_asm },
+                        &mut GlobalAsmContext {
+                            tcx,
+                            global_asm: &mut global_asm,
+                            module,
+                            target_config,
+                            global_asm_sym_index: &mut global_asm_sym_index,
+                        },
                         instance,
                         MonoItemData {
                             linkage: RLinkage::External,
@@ -560,7 +568,13 @@ fn codegen_cgu_content(
             }
             MonoItem::GlobalAsm(item_id) => {
                 rustc_codegen_ssa::base::codegen_global_asm(
-                    &mut GlobalAsmContext { tcx, global_asm: &mut global_asm },
+                    &mut GlobalAsmContext {
+                        tcx,
+                        global_asm: &mut global_asm,
+                        module,
+                        target_config,
+                        global_asm_sym_index: &mut global_asm_sym_index,
+                    },
                     item_id,
                 );
             }

--- a/src/inline_asm.rs
+++ b/src/inline_asm.rs
@@ -575,7 +575,13 @@ impl<'tcx> InlineAssemblyGenerator<'_, 'tcx> {
                         CInlineAsmOperand::Const { ref value } => {
                             generated_asm.push_str(value);
                         }
-                        CInlineAsmOperand::Symbol { ref symbol } => generated_asm.push_str(symbol),
+                        CInlineAsmOperand::Symbol { ref symbol } => {
+                            // For Mach-O, symbols need an underscore prefix
+                            if binary_format == BinaryFormat::Macho {
+                                generated_asm.push('_');
+                            }
+                            generated_asm.push_str(symbol);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

This PR implements full support for `sym` operands in `global_asm!`, addressing the issues mentioned in rust-lang/rustc_codegen_cranelift#1204.

### Changes

1. **Mach-O symbol mangling**: Added underscore prefix for symbol names on Darwin targets (macOS) in both `global_asm` and `inline_asm`

2. **Private function handling**: Created wrapper functions for `SymFn` operands in `global_asm!`. Functions may be private to the current codegen unit and thus not exported from the object file. The wrapper function is exported and can be referenced by the external assembler.

3. **Added module access to `GlobalAsmContext`**: Required for creating wrapper functions in the Cranelift module

### Technical Details

- For `SymFn` operands: A wrapper function is created (similar to what inline_asm already does) that forwards calls to the actual function. The wrapper is exported with `Linkage::Export`.

- For `SymStatic` operands: The symbol is referenced directly with proper Mach-O underscore prefix when needed.

### Test

Added a test in `mini_core_hello_world.rs` that:
- Defines a Rust function `sym_target()` returning 42
- Uses `global_asm!` with `sym` to create an assembly function that jumps to it
- Verifies the assembly function correctly calls through to `sym_target()`
- Supports x86_64 and aarch64 on Linux and macOS

Fixes rust-lang/rustc_codegen_cranelift#1204

🤖 Generated with [Claude Code](https://claude.com/claude-code)