### PR TITLE
Test `graviola` in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,8 @@ jobs:
     - name: Test
       env:
         TARGET_TRIPLE: ${{ matrix.env.TARGET_TRIPLE }}
-      run: ./y.sh test
+      # Skip `graviola` on Windows, too slow
+      run: ./y.sh test ${{ runner.os == 'Windows' && '--skip-test test.graviola' || '' }}
 
     - name: Install LLVM standard library
       run: rustup target add ${{ matrix.env.TARGET_TRIPLE }}
@@ -128,7 +129,8 @@ jobs:
     - name: Test with LLVM sysroot
       env:
         TARGET_TRIPLE: ${{ matrix.env.TARGET_TRIPLE }}
-      run: ./y.sh test --sysroot llvm --no-unstable-features
+      # Skip `graviola` on Windows, too slow
+      run: ./y.sh test --sysroot llvm --no-unstable-features ${{ runner.os == 'Windows' && '--skip-test test.graviola' || '' }}
 
 
   # This job doesn't use cg_clif in any way. It checks that all cg_clif tests work with cg_llvm too.

--- a/build_system/abi_cafe.rs
+++ b/build_system/abi_cafe.rs
@@ -7,6 +7,7 @@ static ABI_CAFE_REPO: GitRepo = GitRepo::github(
     "Gankra",
     "abi-cafe",
     "94d38030419eb00a1ba80e5e2b4d763dcee58db4",
+    &[],
     "6efb4457893c8670",
     "abi-cafe",
 );

--- a/build_system/bench.rs
+++ b/build_system/bench.rs
@@ -12,6 +12,7 @@ static SIMPLE_RAYTRACER_REPO: GitRepo = GitRepo::github(
     "ebobby",
     "simple-raytracer",
     "804a7a21b9e673a482797aa289a18ed480e4d813",
+    &[],
     "ad6f59a2331a3f56",
     "<none>",
 );

--- a/build_system/prepare.rs
+++ b/build_system/prepare.rs
@@ -11,11 +11,13 @@ pub(crate) fn prepare(dirs: &Dirs) {
     std::fs::create_dir_all(&dirs.download_dir).unwrap();
     crate::tests::RAND_REPO.fetch(dirs);
     crate::tests::REGEX_REPO.fetch(dirs);
+    crate::tests::GRAVIOLA_REPO.fetch(dirs);
 }
 
 pub(crate) struct GitRepo {
     url: GitRepoUrl,
     rev: &'static str,
+    submodules: &'static [&'static str],
     content_hash: &'static str,
     patch_name: &'static str,
 }
@@ -71,10 +73,17 @@ impl GitRepo {
         user: &'static str,
         repo: &'static str,
         rev: &'static str,
+        submodules: &'static [&'static str],
         content_hash: &'static str,
         patch_name: &'static str,
     ) -> GitRepo {
-        GitRepo { url: GitRepoUrl::Github { user, repo }, rev, content_hash, patch_name }
+        GitRepo {
+            url: GitRepoUrl::Github { user, repo },
+            rev,
+            submodules,
+            content_hash,
+            patch_name,
+        }
     }
 
     fn download_dir(&self, dirs: &Dirs) -> PathBuf {
@@ -132,6 +141,7 @@ impl GitRepo {
                     &download_dir,
                     &format!("https://github.com/{}/{}.git", user, repo),
                     self.rev,
+                    self.submodules,
                 );
             }
         }
@@ -160,7 +170,7 @@ impl GitRepo {
     }
 }
 
-fn clone_repo(download_dir: &Path, repo: &str, rev: &str) {
+fn clone_repo(download_dir: &Path, repo: &str, rev: &str, submodules: &[&str]) {
     eprintln!("[CLONE] {}", repo);
 
     match fs::remove_dir_all(download_dir) {
@@ -179,6 +189,13 @@ fn clone_repo(download_dir: &Path, repo: &str, rev: &str) {
     let mut checkout_cmd = git_command(download_dir, "checkout");
     checkout_cmd.arg("-q").arg(rev);
     spawn_and_wait(checkout_cmd);
+
+    if !submodules.is_empty() {
+        let mut submodule_cmd = git_command(download_dir, "submodule");
+        submodule_cmd.arg("update").arg("--init");
+        submodule_cmd.args(submodules);
+        spawn_and_wait(submodule_cmd);
+    }
 
     std::fs::remove_dir_all(download_dir.join(".git")).unwrap();
 }

--- a/build_system/tests.rs
+++ b/build_system/tests.rs
@@ -125,6 +125,7 @@ pub(crate) static RAND_REPO: GitRepo = GitRepo::github(
     "rust-random",
     "rand",
     "1f4507a8e1cf8050e4ceef95eeda8f64645b6719",
+    &[],
     "981f8bf489338978",
     "rand",
 );
@@ -135,11 +136,23 @@ pub(crate) static REGEX_REPO: GitRepo = GitRepo::github(
     "rust-lang",
     "regex",
     "061ee815ef2c44101dba7b0b124600fcb03c1912",
+    &[],
     "dc26aefbeeac03ca",
     "regex",
 );
 
 static REGEX: CargoProject = CargoProject::new(REGEX_REPO.source_dir(), "regex_target");
+
+pub(crate) static GRAVIOLA_REPO: GitRepo = GitRepo::github(
+    "ctz",
+    "graviola",
+    "c779b83cfd7114c4802293700c92cfb5e05cb4b7",
+    &["thirdparty/cavp", "thirdparty/wycheproof"],
+    "e0925ceb21a56101",
+    "graviola",
+);
+
+static GRAVIOLA: CargoProject = CargoProject::new(GRAVIOLA_REPO.source_dir(), "graviola_target");
 
 static PORTABLE_SIMD_SRC: RelPath = RelPath::build("portable-simd");
 
@@ -196,6 +209,44 @@ const EXTENDED_SYSROOT_SUITE: &[TestCase] = &[
             eprintln!("Cross-Compiling: Not running tests");
             let mut build_cmd = REGEX.build(&runner.target_compiler, &runner.dirs);
             build_cmd.arg("--tests");
+            spawn_and_wait(build_cmd);
+        }
+    }),
+    TestCase::custom("test.graviola", &|runner| {
+        let (arch, _) = runner.target_compiler.triple.split_once('-').unwrap();
+
+        // FIXME: Disable `aarch64` until intrinsics are supported.
+        if !["x86_64"].contains(&arch) {
+            eprintln!("Skipping `graviola` tests: unsupported target");
+            return;
+        }
+
+        GRAVIOLA_REPO.patch(&runner.dirs);
+        GRAVIOLA.clean(&runner.dirs);
+
+        if runner.is_native {
+            let mut test_cmd = GRAVIOLA.test(&runner.target_compiler, &runner.dirs);
+
+            // FIXME: Disable AVX-512 until intrinsics are supported.
+            test_cmd.env("GRAVIOLA_CPU_DISABLE_avx512f", "1");
+            test_cmd.env("GRAVIOLA_CPU_DISABLE_avx512bw", "1");
+            test_cmd.env("GRAVIOLA_CPU_DISABLE_avx512vl", "1");
+
+            test_cmd.args([
+                "-p",
+                "graviola",
+                "--lib",
+                "--",
+                "-q",
+                // FIXME: Disable AVX-512 until intrinsics are supported.
+                "--skip",
+                "check_counter512",
+            ]);
+            spawn_and_wait(test_cmd);
+        } else {
+            eprintln!("Cross-Compiling: Not running tests");
+            let mut build_cmd = GRAVIOLA.build(&runner.target_compiler, &runner.dirs);
+            build_cmd.args(["-p", "graviola", "--lib"]);
             spawn_and_wait(build_cmd);
         }
     }),

--- a/config.txt
+++ b/config.txt
@@ -36,4 +36,5 @@ test.sysroot
 testsuite.extended_sysroot
 test.rust-random/rand
 test.regex
+test.graviola
 test.portable-simd


### PR DESCRIPTION
Opening as a draft for now, since none of these jobs will actually pass:
- ~~x86_64 needs the rustc fix~~
- aarch64 needs added intrinsics

valgrind is needed due to crabgrind usage: https://github.com/ctz/graviola/blob/v/0.3.2/graviola/src/low/ct.rs#L5

Could consider patching it out, or making it optional upstream.
