### PR TITLE
Fix __eh_frame for AArch64 on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,27 +43,27 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f248321c6a7d4de5dcf2939368e96a397ad3f53b6a076e38d0104d1da326d37"
+checksum = "6edb5bdd1af46714e3224a017fabbbd57f70df4e840eb5ad6a7429dc456119d6"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6d78ff1f7d9bf8b7e1afbedbf78ba49e38e9da479d4c8a2db094e22f64e2bc"
+checksum = "a819599186e1b1a1f88d464e06045696afc7aa3e0cc018aa0b2999cb63d1d088"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6005ba640213a5b95382aeaf6b82bf028309581c8d7349778d66f27dc1180b"
+checksum = "36e2c152d488e03c87b913bc2ed3414416eb1e0d66d61b49af60bf456a9665c7"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -71,18 +71,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fb5b134a12b559ff0c0f5af0fcd755ad380723b5016c4e0d36f74d39485340"
+checksum = "b6559d4fbc253d1396e1f6beeae57fa88a244f02aaf0cde2a735afd3492d9b2e"
 dependencies = [
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85837de8be7f17a4034a6b08816f05a3144345d2091937b39d415990daca28f4"
+checksum = "96d9315d98d6e0a64454d4c83be2ee0e8055c3f80c3b2d7bcad7079f281a06ff"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e433faa87d38e5b8ff469e44a26fea4f93e58abd7a7c10bad9810056139700c9"
+checksum = "d89c00a88081c55e3087c45bebc77e0cc973de2d7b44ef6a943c7122647b89f5"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -119,24 +119,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5397ba61976e13944ca71230775db13ee1cb62849701ed35b753f4761ed0a9b7"
+checksum = "879f77c497a1eb6273482aa1ac3b23cb8563ff04edb39ed5dfcfd28c8deff8f5"
 
 [[package]]
 name = "cranelift-control"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc81c88765580720eb30f4fc2c1bfdb75fcbf3094f87b3cd69cecca79d77a245"
+checksum = "498dc1f17a6910c88316d49c7176d8fa97cf10c30859c32a266040449317f963"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463feed5d46cf8763f3ba3045284cf706dd161496e20ec9c14afbb4ba09b9e66"
+checksum = "c2acba797f6a46042ce82aaf7680d0c3567fe2001e238db9df649fd104a2727f"
 dependencies = [
  "cranelift-bitset",
  "wasmtime-internal-core",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c5eca7696c1c04ab4c7ed8d18eadbb47d6cc9f14ec86fe0881bf1d7e97e261"
+checksum = "4dca3df1d107d98d88f159ad1d5eaa2d5cdb678b3d5bcfadc6fc83d8ebb448ea"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -156,15 +156,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1153844610cc9c6da8cf10ce205e45da1a585b7688ed558aa808bbe2e4e6d77"
+checksum = "f62dd18116d88bed649871feceda79dad7b59cc685ea8998c2b3e64d0e689602"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41836de8321b303d3d4188e58cc09c30c7645337342acfcfb363732695cae098"
+checksum = "0a4942770ce6662b44d903493d7c5b00f9a986a713a61aae148306eaef21ebd4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b731f66cb1b69b60a74216e632968ebdbb95c488d26aa1448ec226ae0ffec33e"
+checksum = "fb5ca0d214ecee44405ea9f0c65a5318b41ac469e8258fd9fe944e564c1c1b0b"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97b583fe9a60f06b0464cee6be5a17f623fd91b217aaac99b51b339d19911af"
+checksum = "f843b80360d7fdf61a6124642af7597f6d55724cf521210c34af8a1c66daca6e"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9809d2d419cd18f17377f4ce64a7ad22eeda0d042c08833d3796657f1ddebc82"
+checksum = "b9d212d15015c374333b11b833111b7c7e686bfaec02385af53611050bce7e9d"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8594dc6bb4860fa8292f1814c76459dbfb933e1978d8222de6380efce45c7cee"
+checksum = "090ee5de58c6f17eb5e3a5ae8cf1695c7efea04ec4dd0ecba6a5b996c9bad7dc"
 
 [[package]]
 name = "crc32fast"
@@ -338,9 +338,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "object"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
+checksum = "63944c133d03f44e75866bbd160b95af0ec3f6a13d936d69d31c81078cbc5baf"
 dependencies = [
  "crc32fast",
  "hashbrown 0.16.1",
@@ -482,9 +482,9 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "43.0.0"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e671917bb6856ae360cb59d7aaf26f1cfd042c7b924319dd06fd380739fc0b2e"
+checksum = "816a61a75275c6be435131fc625a4f5956daf24d9f9f59443e81cbef228929b3"
 dependencies = [
  "hashbrown 0.16.1",
  "libm",
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "43.0.0"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3112806515fac8495883885eb8dbdde849988ae91fe6beb544c0d7c0f4c9aa"
+checksum = "2fd683a94490bf755d016a09697b0955602c50106b1ded97d16983ab2ded9fed"
 dependencies = [
  "cfg-if",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,12 +294,12 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -338,12 +347,12 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "object"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63944c133d03f44e75866bbd160b95af0ec3f6a13d936d69d31c81078cbc5baf"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap",
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ crate-type = ["dylib"]
 
 [dependencies]
 # These have to be in sync with each other
-cranelift-codegen = { version = "0.130.0", default-features = false, features = ["std", "timing", "unwind", "all-native-arch"] }
-cranelift-frontend = { version = "0.130.0" }
-cranelift-module = { version = "0.130.0" }
-cranelift-native = { version = "0.130.0" }
-cranelift-jit = { version = "0.130.0", optional = true }
-cranelift-object = { version = "0.130.0" }
+cranelift-codegen = { version = "0.131.0", default-features = false, features = ["std", "timing", "unwind", "all-native-arch"] }
+cranelift-frontend = { version = "0.131.0" }
+cranelift-module = { version = "0.131.0" }
+cranelift-native = { version = "0.131.0" }
+cranelift-jit = { version = "0.131.0", optional = true }
+cranelift-object = { version = "0.131.0" }
 target-lexicon = "0.13"
 gimli = { version = "0.33", default-features = false, features = ["write"] }
-object = { version = "0.38.0", default-features = false, features = ["std", "read_core", "write", "archive", "coff", "elf", "macho", "pe"] }
+object = { version = "0.39.0", default-features = false, features = ["std", "read_core", "write", "archive", "coff", "elf", "macho", "pe"] }
 
 indexmap = "2.0.0"
 libloading = { version = "0.9.0", optional = true }
@@ -24,12 +24,12 @@ smallvec = "1.8.1"
 
 [patch.crates-io]
 # Uncomment to use an unreleased version of cranelift
-#cranelift-codegen = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "release-43.0.0" }
-#cranelift-frontend = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "release-43.0.0" }
-#cranelift-module = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "release-43.0.0" }
-#cranelift-native = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "release-43.0.0" }
-#cranelift-jit = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "release-43.0.0" }
-#cranelift-object = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "release-43.0.0" }
+#cranelift-codegen = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "release-44.0.0" }
+#cranelift-frontend = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "release-44.0.0" }
+#cranelift-module = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "release-44.0.0" }
+#cranelift-native = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "release-44.0.0" }
+#cranelift-jit = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "release-44.0.0" }
+#cranelift-object = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "release-44.0.0" }
 
 # Uncomment to use local checkout of cranelift
 #cranelift-codegen = { path = "../wasmtime/cranelift/codegen" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ cranelift-jit = { version = "0.131.0", optional = true }
 cranelift-object = { version = "0.131.0" }
 target-lexicon = "0.13"
 gimli = { version = "0.33", default-features = false, features = ["write"] }
-object = { version = "0.39.0", default-features = false, features = ["std", "read_core", "write", "archive", "coff", "elf", "macho", "pe"] }
+object = { version = "0.39.1", default-features = false, features = ["std", "read_core", "write", "archive", "coff", "elf", "macho", "pe"] }
 
 indexmap = "2.0.0"
 libloading = { version = "0.9.0", optional = true }

--- a/src/debuginfo/emit.rs
+++ b/src/debuginfo/emit.rs
@@ -43,7 +43,7 @@ impl DebugContext {
         let _: Result<()> = sections.for_each(|id, section| {
             if let Some(section_id) = section_map.get(&id) {
                 for reloc in &section.relocs {
-                    product.add_debug_reloc(&section_map, section_id, reloc);
+                    product.add_debug_reloc(&section_map, section_id, reloc, true);
                 }
             }
             Ok(())

--- a/src/debuginfo/object.rs
+++ b/src/debuginfo/object.rs
@@ -1,7 +1,7 @@
 use cranelift_module::{DataId, FuncId};
 use cranelift_object::ObjectProduct;
 use gimli::SectionId;
-use object::write::{Relocation, StandardSegment};
+use object::write::{Relocation, StandardSection, StandardSegment};
 use object::{RelocationEncoding, RelocationFlags, SectionKind};
 use rustc_data_structures::fx::FxHashMap;
 
@@ -16,6 +16,7 @@ pub(super) trait WriteDebugInfo {
         section_map: &FxHashMap<SectionId, Self::SectionId>,
         from: &Self::SectionId,
         reloc: &DebugReloc,
+        use_section_symbol: bool,
     );
 }
 
@@ -27,29 +28,31 @@ impl WriteDebugInfo for ObjectProduct {
         id: SectionId,
         data: Vec<u8>,
     ) -> (object::write::SectionId, object::write::SymbolId) {
-        let name = if self.object.format() == object::BinaryFormat::MachO {
-            id.name().replace('.', "__") // machO expects __debug_info instead of .debug_info
+        let (section_id, align);
+        if id == SectionId::EhFrame {
+            section_id = self.object.section_id(StandardSection::EhFrame);
+            align = 8;
         } else {
-            id.name().to_string()
-        }
-        .into_bytes();
-
-        let segment = self.object.segment_name(StandardSegment::Debug).to_vec();
-        // FIXME use SHT_X86_64_UNWIND for .eh_frame
-        let section_id = self.object.add_section(
-            segment,
-            name,
-            if id == SectionId::DebugStr || id == SectionId::DebugLineStr {
-                SectionKind::DebugString
-            } else if id == SectionId::EhFrame {
-                SectionKind::ReadOnlyData
+            let name = if self.object.format() == object::BinaryFormat::MachO {
+                id.name().replace('.', "__") // machO expects __debug_info instead of .debug_info
             } else {
-                SectionKind::Debug
-            },
-        );
-        self.object
-            .section_mut(section_id)
-            .set_data(data, if id == SectionId::EhFrame { 8 } else { 1 });
+                id.name().to_string()
+            }
+            .into_bytes();
+
+            let segment = self.object.segment_name(StandardSegment::Debug).to_vec();
+            section_id = self.object.add_section(
+                segment,
+                name,
+                if id == SectionId::DebugStr || id == SectionId::DebugLineStr {
+                    SectionKind::DebugString
+                } else {
+                    SectionKind::Debug
+                },
+            );
+            align = 1;
+        }
+        self.object.section_mut(section_id).set_data(data, align);
         let symbol_id = self.object.section_symbol(section_id);
         (section_id, symbol_id)
     }
@@ -59,6 +62,7 @@ impl WriteDebugInfo for ObjectProduct {
         section_map: &FxHashMap<SectionId, Self::SectionId>,
         from: &Self::SectionId,
         reloc: &DebugReloc,
+        use_section_symbol: bool,
     ) {
         let (symbol, symbol_offset) = match reloc.name {
             DebugRelocName::Section(id) => (section_map.get(&id).unwrap().1, 0),
@@ -69,7 +73,11 @@ impl WriteDebugInfo for ObjectProduct {
                 } else {
                     self.data_symbol(DataId::from_u32(id & !(1 << 31)))
                 };
-                self.object.symbol_section_and_offset(symbol_id).unwrap_or((symbol_id, 0))
+                if use_section_symbol {
+                    self.object.symbol_section_and_offset(symbol_id).unwrap_or((symbol_id, 0))
+                } else {
+                    (symbol_id, 0)
+                }
             }
         };
         self.object

--- a/src/debuginfo/unwind.rs
+++ b/src/debuginfo/unwind.rs
@@ -120,13 +120,12 @@ impl UnwindContext {
         func_id: FuncId,
         context: &Context,
     ) {
-        if let target_lexicon::OperatingSystem::MacOSX { .. } =
-            module.isa().triple().operating_system
+        let triple = module.isa().triple();
+        if matches!(triple.operating_system, target_lexicon::OperatingSystem::MacOSX { .. })
+            && triple.architecture == target_lexicon::Architecture::X86_64
         {
             // The object crate doesn't currently support DW_GNU_EH_PE_absptr, which macOS
-            // requires for unwinding tables. In addition on arm64 it currently doesn't
-            // support 32bit relocations as we currently use for the unwinding table.
-            // See gimli-rs/object#415 and rust-lang/rustc_codegen_cranelift#1371
+            // requires for unwinding tables. See gimli-rs/object#415.
             return;
         }
 
@@ -250,8 +249,9 @@ impl UnwindContext {
             let mut section_map = FxHashMap::default();
             section_map.insert(id, section_id);
 
+            let use_section_symbol = product.object.format() != object::BinaryFormat::MachO;
             for reloc in &eh_frame.0.relocs {
-                product.add_debug_reloc(&section_map, &section_id, reloc);
+                product.add_debug_reloc(&section_map, &section_id, reloc, use_section_symbol);
             }
         }
     }

--- a/src/pretty_clif.rs
+++ b/src/pretty_clif.rs
@@ -60,7 +60,6 @@ use std::fmt;
 use std::io::Write;
 
 use cranelift_codegen::entity::SecondaryMap;
-use cranelift_codegen::ir::Fact;
 use cranelift_codegen::ir::entities::AnyEntity;
 use cranelift_codegen::write::{FuncWriter, PlainWriter};
 use rustc_middle::ty::print::with_no_trimmed_paths;
@@ -182,13 +181,8 @@ impl FuncWriter for &'_ CommentWriter {
         _func: &Function,
         entity: AnyEntity,
         value: &dyn fmt::Display,
-        maybe_fact: Option<&Fact>,
     ) -> fmt::Result {
-        if let Some(fact) = maybe_fact {
-            write!(w, "    {} ! {} = {}", entity, fact, value)?;
-        } else {
-            write!(w, "    {} = {}", entity, value)?;
-        }
+        write!(w, "    {} = {}", entity, value)?;
 
         if let Some(comment) = self.entity_comments.get(&entity) {
             writeln!(w, " ; {}", comment.replace('\n', "\n; "))


### PR DESCRIPTION
The relocations must use symbols (not sections), and the relative relocation needs ARM64_RELOC_SUBTRACTOR.

The section must be in __TEXT rather than __DWARF, which is handled by using StandardSection::EhFrame. This also changes the section type for ELF x86-64.

Depends on https://github.com/gimli-rs/object/pull/856