### PR TITLE
Fix compilation for custom JSON targets

### DIFF
--- a/src/global_asm.rs
+++ b/src/global_asm.rs
@@ -235,6 +235,9 @@ pub(crate) fn compile_global_asm(
             .arg("-")
             .arg("-Abad_asm_style")
             .arg("-Zcodegen-backend=llvm")
+            // JSON targets currently require `-Zunstable-options`
+            // Tracking issue: https://github.com/rust-lang/rust/issues/151528
+            .arg("-Zunstable-options")
             .stdin(Stdio::piped())
             .spawn()
             .expect("Failed to spawn `as`.");


### PR DESCRIPTION
A very simple change to allow compilation with custom JSON targets. Previously the Cranelift backend (and not LLVM) would produce an error as the `rustc` assembler process expected `-Zunstable-options` when JSON targets were used.

Skipped doing fancier logic as always passing `-Zunstable-options` seems to work fine, but could be wrong! Happy to change things if I'm wrong about how that works :)