### PR TITLE
Parse and set Mach-O section type and attributes

### DIFF
--- a/src/constant.rs
+++ b/src/constant.rs
@@ -414,49 +414,7 @@ fn define_all_allocs(tcx: TyCtxt<'_>, module: &mut dyn Module, cx: &mut Constant
         data.set_align(alloc.align.bytes());
 
         if let Some(section_name) = section_name {
-            let (segment_name, section_name) = if tcx.sess.target.is_like_darwin {
-                // See https://github.com/llvm/llvm-project/blob/main/llvm/lib/MC/MCSectionMachO.cpp
-                let mut parts = section_name.as_str().split(',');
-                let Some(segment_name) = parts.next() else {
-                    tcx.dcx().fatal(format!(
-                        "#[link_section = \"{}\"] is not valid for macos target: must be segment and section separated by comma",
-                        section_name
-                    ));
-                };
-                let Some(section_name) = parts.next() else {
-                    tcx.dcx().fatal(format!(
-                        "#[link_section = \"{}\"] is not valid for macos target: must be segment and section separated by comma",
-                        section_name
-                    ));
-                };
-                if section_name.len() > 16 {
-                    tcx.dcx().fatal(format!(
-                        "#[link_section = \"{}\"] is not valid for macos target: section name bigger than 16 bytes",
-                        section_name
-                    ));
-                }
-                let section_type = parts.next().unwrap_or("regular");
-                if section_type != "regular" && section_type != "cstring_literals" {
-                    tcx.dcx().fatal(format!(
-                        "#[link_section = \"{}\"] is not supported: unsupported section type {}",
-                        section_name, section_type,
-                    ));
-                }
-                let _attrs = parts.next();
-                if parts.next().is_some() {
-                    tcx.dcx().fatal(format!(
-                        "#[link_section = \"{}\"] is not valid for macos target: too many components",
-                        section_name
-                    ));
-                }
-                // FIXME(bytecodealliance/wasmtime#8901) set S_CSTRING_LITERALS section type when
-                // cstring_literals is specified
-                (segment_name, section_name)
-            } else {
-                ("", section_name.as_str())
-            };
-            // FIXME pass correct section flags on Mach-O
-            data.set_segment_section(segment_name, section_name, 0);
+            data.set_custom_section(section_name.as_str());
         }
 
         let bytes = alloc.inspect_with_uninit_and_ptr_outside_interpreter(0..alloc.len()).to_vec();

--- a/src/debuginfo/unwind.rs
+++ b/src/debuginfo/unwind.rs
@@ -204,7 +204,7 @@ impl UnwindContext {
 
                     let mut data = DataDescription::new();
                     data.define(gcc_except_table.writer.into_vec().into_boxed_slice());
-                    data.set_segment_section("", ".gcc_except_table", 0);
+                    data.set_custom_section(".gcc_except_table");
 
                     for reloc in &gcc_except_table.relocs {
                         match reloc.name {


### PR DESCRIPTION
Mach-O sections have a 32-bit "flags" parameter, which contains 8 bits for a "section type", and 24 bits for "attributes". These can be controlled with `#[link_section = ...]` like so:
```rust
// Sets the section type to S_MOD_INIT_FUNC_POINTERS
#[unsafe(link_section = "__DATA,__mod_init_func,mod_init_funcs")]
static CONSTRUCTOR: extern "C" fn() = ...;

// Sets the section type to S_CSTRING_LITERALS
#[link_section = "__TEXT,__cstring,cstring_literals"]
static NAME_DATA: [u8; 4] = b"foo\0";

#[unsafe(link_section = "__TEXT,__text,regular,pure_instructions+no_dead_strip")]
static LINKER_USED_INSTRUCTIONS: [u8; 10] = ...;
```

The default section type is "regular" (`S_REGULAR`).

This PR parses the section type names and attribute names understood by LLVM, and convert them to the corresponding Mach-O flags.

Fixes https://github.com/rust-lang/rustc_codegen_cranelift/issues/1588.
Fixes https://github.com/bevyengine/bevy/issues/20785.
Depends on https://github.com/bytecodealliance/wasmtime/pull/13137.

Related to https://github.com/rust-lang/rust/pull/155065, we could also put this parsing logic higher up, to rely less on LLVM / get diagnostics with spans for this on all backends?