### PR TITLE
Truncate IR dump basenames to respect NAME_MAX

### DIFF
--- a/src/pretty_clif.rs
+++ b/src/pretty_clif.rs
@@ -265,7 +265,7 @@ pub(crate) fn write_ir_file(
         res @ Err(_) => res.unwrap(),
     }
 
-    let clif_file_name = clif_output_dir.join(name);
+    let clif_file_name = clif_output_dir.join(truncate_ir_basename(name).as_ref());
 
     let res = std::fs::File::create(clif_file_name).and_then(|mut file| write(&mut file));
     if let Err(err) = res {
@@ -276,6 +276,41 @@ pub(crate) fn write_ir_file(
     }
 }
 
+/// Ensure a generated IR filename fits in the filesystem's per-component
+/// length limit. Symbol-mangled names can exceed `NAME_MAX` (255 on ext4,
+/// 143 on HFS+), which causes `ENAMETOOLONG` on `File::create`.
+///
+/// Names ≤ 200 bytes pass through unchanged. Longer names are rewritten to
+/// `<first 160 bytes of stem>_h<16-hex-FNV-1a-64 of full stem>.<extensions>`.
+/// The hash is computed over the original stem so the transformation is
+/// deterministic and any two distinct inputs map to distinct outputs.
+fn truncate_ir_basename(name: &str) -> std::borrow::Cow<'_, str> {
+    const MAX_BASENAME_LEN: usize = 200;
+    if name.len() <= MAX_BASENAME_LEN {
+        return std::borrow::Cow::Borrowed(name);
+    }
+    // Preserve extension suffix chain (e.g. ".opt.clif", ".unopt.clif", ".vcode").
+    let (stem, ext) = match name.find('.') {
+        Some(i) => (&name[..i], &name[i..]),
+        None => (name, ""),
+    };
+    // FNV-1a 64-bit over the *full stem* (not the truncated prefix) so two
+    // inputs sharing a long common prefix still hash apart.
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for b in stem.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    // Char-boundary-safe truncation of the stem prefix.
+    let keep_bytes = 160.min(stem.len());
+    let mut cut = keep_bytes;
+    while cut > 0 && !stem.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let prefix = &stem[..cut];
+    std::borrow::Cow::Owned(format!("{prefix}_h{hash:016x}{ext}"))
+}
+
 pub(crate) fn write_clif_file(
     output_filenames: &OutputFilenames,
     symbol_name: &str,
@@ -284,7 +319,6 @@ pub(crate) fn write_clif_file(
     func: &cranelift_codegen::ir::Function,
     mut clif_comments: &CommentWriter,
 ) {
-    // FIXME work around filename too long errors
     write_ir_file(output_filenames, &format!("{}.{}.clif", symbol_name, postfix), |file| {
         let mut clif = String::new();
         cranelift_codegen::write::decorate_function(&mut clif_comments, &mut clif, func).unwrap();


### PR DESCRIPTION
Resolves the `// FIXME work around filename too long errors` marker at `src/pretty_clif.rs:287` that has been in place since the CLIF-dump infrastructure was added.

### Problem

Symbol-mangled Rust names can easily exceed the per-component filename length limit enforced by most filesystems (255 bytes on ext4/XFS/Btrfs/APFS, 143 on HFS+, 255 UTF-16 code units on NTFS). When `--emit=llvm-ir` is passed, cg_clif dumps one CLIF file (and in \`base.rs\` one \`.vcode\` file) per function to `<crate>.clif/<symbol>.opt.clif` et al. For large dependency graphs — notably `core`, `alloc`, `hashbrown`, `compiler-builtins` — several functions mangle to 240–300 byte basenames, which trips \`ENAMETOOLONG\` from \`File::create\`. The current behaviour is to swallow the error via \`early_warn\` and silently drop the dump, making \`--emit=llvm-ir\` unreliable for any non-trivial crate.

### Fix

Introduce `truncate_ir_basename` inside `pretty_clif.rs`:

- Names ≤ 200 bytes pass through unchanged (common case: zero overhead, borrowed `Cow`).
- Longer names are rewritten to `<first 160 bytes of stem>_h<16-hex-FNV-1a-64 of full stem>.<extensions>`.
- The hash is computed over the **full original stem**, so any two distinct inputs map to distinct outputs with overwhelming probability, even when sharing a long common prefix.
- Extension suffix chains (`.opt.clif`, `.unopt.clif`, `.vcode`) are preserved verbatim, so downstream tooling keying off the extension continues to work.
- Truncation is char-boundary-safe (falls back to a shorter prefix if the 160-byte cut lands mid-UTF-8).

The call sits inside `write_ir_file`, so both `write_clif_file` and the `.vcode` writer in `base.rs` benefit without changes.

### Verification

Verified locally against a `-Zbuild-std=core,alloc` build with `--emit=llvm-ir`: before the patch, multiple dumps fail silently with `ENAMETOOLONG`; after the patch, every expected file is written, longest basename is exactly 200 bytes, and the truncated ones carry the `_h<hex>` marker at the expected offset.

### Backward compatibility

- No effect on any name ≤ 200 bytes — bit-for-bit identical filenames.
- Changes file names only for inputs that previously failed outright, so there is no regression path for existing consumers.
- No change to the actual CLIF/vcode file contents.