### PR TITLE
Implement aarch64 CRC32 LLVM intrinsics

### DIFF
--- a/example/neon.rs
+++ b/example/neon.rs
@@ -10,6 +10,25 @@ use std::mem::transmute;
 use std::simd::*;
 
 #[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "crc")]
+unsafe fn test_crc32() {
+    assert!(std::arch::is_aarch64_feature_detected!("crc"));
+
+    let a: u32 = 42;
+    let b: u64 = 0xdeadbeef;
+
+    assert_eq!(__crc32b(a, b as u8), 0xEB0E363F);
+    assert_eq!(__crc32h(a, b as u16), 0x9A54BD80);
+    assert_eq!(__crc32w(a, b as u32), 0xF491F059);
+    assert_eq!(__crc32d(a, b as u64), 0xD14BBEA6);
+
+    assert_eq!(__crc32cb(a, b as u8), 0xF67C32D8);
+    assert_eq!(__crc32ch(a, b as u16), 0x479108B8);
+    assert_eq!(__crc32cw(a, b as u32), 0x979F49F8);
+    assert_eq!(__crc32cd(a, b as u64), 0x0E6BE593);
+}
+
+#[cfg(target_arch = "aarch64")]
 unsafe fn test_vpmin_s8() {
     let a = i8x8::from([1, -2, 3, -4, 5, 6, 7, 8]);
     let b = i8x8::from([0, 3, 2, 5, 4, 7, 6, 9]);
@@ -272,6 +291,8 @@ fn main() {
         test_vminq_f32();
         test_vaddvq_f32();
         test_vrndnq_f32();
+
+        test_crc32();
     }
 }
 

--- a/src/intrinsics/llvm_aarch64.rs
+++ b/src/intrinsics/llvm_aarch64.rs
@@ -494,6 +494,56 @@ pub(super) fn codegen_aarch64_llvm_intrinsic_call<'tcx>(
             });
         }
         */
+        "llvm.aarch64.crc32b"
+        | "llvm.aarch64.crc32h"
+        | "llvm.aarch64.crc32w"
+        | "llvm.aarch64.crc32x"
+        | "llvm.aarch64.crc32cb"
+        | "llvm.aarch64.crc32ch"
+        | "llvm.aarch64.crc32cw"
+        | "llvm.aarch64.crc32cx" => {
+            // ARM ARM v8-A: CRC32{,C}{B,H,W,X}.
+            // Backs core::arch::aarch64::__crc32{,c}{b,h,w,d}.
+            intrinsic_args!(fx, args => (crc, v); intrinsic);
+
+            let crc = crc.load_scalar(fx);
+            let v = v.load_scalar(fx);
+
+            let asm = match intrinsic {
+                "llvm.aarch64.crc32b" => "crc32b  w0, w0, w1",
+                "llvm.aarch64.crc32h" => "crc32h  w0, w0, w1",
+                "llvm.aarch64.crc32w" => "crc32w  w0, w0, w1",
+                "llvm.aarch64.crc32x" => "crc32x  w0, w0, x1",
+                "llvm.aarch64.crc32cb" => "crc32cb w0, w0, w1",
+                "llvm.aarch64.crc32ch" => "crc32ch w0, w0, w1",
+                "llvm.aarch64.crc32cw" => "crc32cw w0, w0, w1",
+                "llvm.aarch64.crc32cx" => "crc32cx w0, w0, x1",
+                _ => unreachable!(),
+            };
+
+            codegen_inline_asm_inner(
+                fx,
+                &[InlineAsmTemplatePiece::String(asm.into())],
+                &[
+                    CInlineAsmOperand::InOut {
+                        reg: InlineAsmRegOrRegClass::Reg(InlineAsmReg::AArch64(
+                            AArch64InlineAsmReg::x0,
+                        )),
+                        _late: true,
+                        in_value: crc,
+                        out_place: Some(ret),
+                    },
+                    CInlineAsmOperand::In {
+                        reg: InlineAsmRegOrRegClass::Reg(InlineAsmReg::AArch64(
+                            AArch64InlineAsmReg::x1,
+                        )),
+                        value: v,
+                    },
+                ],
+                InlineAsmOptions::NOSTACK | InlineAsmOptions::PURE | InlineAsmOptions::NOMEM,
+            );
+        }
+
         _ => {
             fx.tcx.dcx().warn(format!(
                 "unsupported AArch64 llvm intrinsic {}; replacing with trap",


### PR DESCRIPTION
Adds support for the eight `llvm.aarch64.crc32{,c}{b,h,w,x}` intrinsics by lowering them to `crc32{,c}{b,h,w,x}` inline assembly via the existing `codegen_inline_asm_inner` helper. Mirrors PR rust-lang/rustc_codegen_cranelift#1490 (the x86 sse42.crc32 family).

This unblocks `crc32fast` on aarch64 under the cranelift backend, which is pulled in transitively by common crates including `png` → `image` and Bevy's PNG screenshot path. Multiple users have reported this in rust-lang/rustc_codegen_cranelift#171 over the past year (`llvm.aarch64.crc32b` blocking Tauri builds, `llvm.aarch64.crc32x` blocking utoipa-swagger-ui, etc.).

## What's covered

| LLVM intrinsic | AArch64 instruction | Rust intrinsic |
|---|---|---|
| \`llvm.aarch64.crc32b\`  | \`crc32b  Wd, Wn, Wm\` | \`__crc32b\`  |
| \`llvm.aarch64.crc32h\`  | \`crc32h  Wd, Wn, Wm\` | \`__crc32h\`  |
| \`llvm.aarch64.crc32w\`  | \`crc32w  Wd, Wn, Wm\` | \`__crc32w\`  |
| \`llvm.aarch64.crc32x\`  | \`crc32x  Wd, Wn, Xm\` | \`__crc32d\`  |
| \`llvm.aarch64.crc32cb\` | \`crc32cb Wd, Wn, Wm\` | \`__crc32cb\` |
| \`llvm.aarch64.crc32ch\` | \`crc32ch Wd, Wn, Wm\` | \`__crc32ch\` |
| \`llvm.aarch64.crc32cw\` | \`crc32cw Wd, Wn, Wm\` | \`__crc32cw\` |
| \`llvm.aarch64.crc32cx\` | \`crc32cx Wd, Wn, Xm\` | \`__crc32cd\` |

## Tests

\`example/neon.rs\` extended with \`test_crc32()\` covering all eight intrinsics. Reference values were generated by running the same call sequence under the LLVM backend on \`aarch64-apple-darwin\` and pasted into the assertions.

Verified locally on \`aarch64-apple-darwin\`:
- Full \`./test.sh\` passes.
- End-to-end smoke test: a tiny crate depending on \`crc32fast = \"1.5\"\` compiles and runs under cg_clif, producing a CRC matching \`zlib.crc32\`.

Refs rust-lang/rustc_codegen_cranelift#171