### PR TITLE
ci: monthly Cranelift release branch automation regex

### DIFF
--- a/.github/workflows/cranelift-release-branch.yml
+++ b/.github/workflows/cranelift-release-branch.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Patch Cargo.toml to use release branch Cranelift
         run: |
-          sed -i -E 's/"0\.13[0-9]\.[0-9]+"/"*"/g' Cargo.toml
+          sed -i -E '/cranelift-/s/"0\.[0-9]+\.0"/"*"/g' Cargo.toml
 
           cat >>Cargo.toml <<EOF
           [patch.crates-io]

--- a/.github/workflows/cranelift-release-branch.yml
+++ b/.github/workflows/cranelift-release-branch.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Patch Cargo.toml to use release branch Cranelift
         run: |
-          sed -i 's/"0\.131\.0"/"*"/g' Cargo.toml
+          sed -i -E 's/"0\.13[0-9]\.[0-9]+"/"*"/g' Cargo.toml
 
           cat >>Cargo.toml <<EOF
           [patch.crates-io]

--- a/.github/workflows/cranelift-release-branch.yml
+++ b/.github/workflows/cranelift-release-branch.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Patch Cargo.toml to use release branch Cranelift
         run: |
+          sed -i 's/"0\.131\.0"/"*"/g' Cargo.toml
+
           cat >>Cargo.toml <<EOF
           [patch.crates-io]
           cranelift-codegen = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "$(echo $WASMTIME_RELEASE_BRANCH)" }
@@ -47,7 +49,8 @@ jobs:
           cranelift-jit = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "$(echo $WASMTIME_RELEASE_BRANCH)" }
           cranelift-object = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "$(echo $WASMTIME_RELEASE_BRANCH)" }
           EOF
-          cargo check -p rustc-hash # update lockfile
+          
+          cargo update
         env:
           WASMTIME_RELEASE_BRANCH: ${{ steps.wasmtime_release_branch.outputs.branch }}
 


### PR DESCRIPTION
fix: rust-lang/rustc_codegen_cranelift#1663 

Previously, Cargo was ignoring the patch because of strict `0.a.b` version mismatches between the `Cargo.toml` lock and new release branch. I added a `sed` step to temporarily replace the hardcoded Cranelift versions with a `*` during the CI run so Cargo accepts the patch.

temp edit: the (build)sysroot CI fails ,coz now `MemFlags` has been replaced by `MemFlagsData`,`set_notrap()` is now a chained builder, etc.