### PR TITLE
Support pointer valued inline asm const operands

### DIFF
--- a/scripts/test_rustc_tests.sh
+++ b/scripts/test_rustc_tests.sh
@@ -172,8 +172,6 @@ rm tests/ui/process/println-with-broken-pipe.rs # same
 rm -r tests/run-make/extern-fn-explicit-align # argument alignment not yet supported
 rm -r tests/run-make/panic-abort-eh_frame # .eh_frame emitted with panic=abort
 rm -r tests/run-make/used-proc-macro # doesn't work on arm64 for some reason
-rm tests/ui/asm/asm-const-ptr-mir-inline.rs # const sym in inline asm gives ICE
-rm tests/ui/asm/const-refs-to-static.rs # same
 
 # bugs in the test suite
 # ======================

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -241,7 +241,7 @@ fn pointer_for_allocation<'tcx>(fx: &mut FunctionCx<'_, '_, 'tcx>, alloc_id: All
     fx.bcx.ins().symbol_value(fx.pointer_type, local_data_id)
 }
 
-fn data_id_for_alloc_id(
+pub(crate) fn data_id_for_alloc_id(
     cx: &mut ConstantCx,
     module: &mut dyn Module,
     alloc_id: AllocId,

--- a/src/inline_asm.rs
+++ b/src/inline_asm.rs
@@ -6,6 +6,7 @@ use cranelift_codegen::isa::CallConv;
 use rustc_abi::CanonAbi;
 use rustc_ast::ast::{InlineAsmOptions, InlineAsmTemplatePiece};
 use rustc_hir::LangItem;
+use rustc_middle::mir::interpret::{GlobalAlloc, PointerArithmetic, Scalar as ConstScalar};
 use rustc_middle::ty::layout::FnAbiOf;
 use rustc_span::sym;
 use rustc_target::asm::*;
@@ -104,13 +105,64 @@ pub(crate) fn codegen_inline_asm_terminator<'tcx>(
                     )
                 };
 
-                let value = rustc_codegen_ssa::common::asm_const_to_str(
-                    fx.tcx,
-                    span,
-                    scalar.assert_scalar_int(),
-                    fx.layout_of(ty),
-                );
-                CInlineAsmOperand::Const { value }
+                match scalar {
+                    ConstScalar::Int(int) => {
+                        let value = rustc_codegen_ssa::common::asm_const_to_str(
+                            fx.tcx,
+                            span,
+                            int,
+                            fx.layout_of(ty),
+                        );
+                        CInlineAsmOperand::Const { value }
+                    }
+                    ConstScalar::Ptr(ptr, _) => {
+                        if cfg!(not(feature = "inline_asm_sym")) {
+                            fx.tcx.dcx().span_err(
+                                span,
+                                "asm! and global_asm! sym operands are not yet supported",
+                            );
+                        }
+
+                        let (prov, offset) = ptr.prov_and_relative_offset();
+
+                        let alloc_id = prov.alloc_id();
+
+                        let mut symbol = match fx.tcx.global_alloc(alloc_id) {
+                            GlobalAlloc::Function { instance, .. } => {
+                                fx.tcx.symbol_name(instance).name.to_owned()
+                            }
+                            GlobalAlloc::Static(def_id) => {
+                                fx.tcx.symbol_name(Instance::mono(fx.tcx, def_id)).name.to_owned()
+                            }
+                            GlobalAlloc::Memory(alloc) => {
+                                let data_id = crate::constant::data_id_for_alloc_id(
+                                    &mut fx.constants_cx,
+                                    fx.module,
+                                    alloc_id,
+                                    alloc.inner().mutability,
+                                );
+                                fx.module
+                                    .declarations()
+                                    .get_data_decl(data_id)
+                                    .linkage_name(data_id)
+                                    .into_owned()
+                            }
+                            GlobalAlloc::VTable(..) | GlobalAlloc::TypeId { .. } => {
+                                span_bug!(
+                                    span,
+                                    "unsupported allocation for inline asm const pointer"
+                                )
+                            }
+                        };
+
+                        if offset != Size::ZERO {
+                            let offset = fx.tcx.sign_extend_to_target_isize(offset.bytes());
+                            write!(symbol, "{offset:+}").unwrap();
+                        }
+
+                        CInlineAsmOperand::Symbol { symbol }
+                    }
+                }
             }
             InlineAsmOperand::SymFn { ref value } => {
                 if cfg!(not(feature = "inline_asm_sym")) {


### PR DESCRIPTION
Fixes rust-lang/rust#159979