### PR TITLE
Prevent `RUSTFLAGS` leak in bench build

### DIFF
--- a/build_system/bench.rs
+++ b/build_system/bench.rs
@@ -67,7 +67,7 @@ pub(crate) fn benchmark(dirs: &Dirs, compiler: &Compiler) {
         target_dir = target_dir.display(),
     );
     let llvm_build_cmd = format!(
-        "RUSTC=rustc cargo build --manifest-path {manifest_path} --target-dir {target_dir} && (rm {raytracer_cg_llvm} || true) && ln {target_dir}/debug/main {raytracer_cg_llvm}",
+        "RUSTC=rustc CARGO_ENCODED_RUSTFLAGS=\"\" cargo build --manifest-path {manifest_path} --target-dir {target_dir} && (rm {raytracer_cg_llvm} || true) && ln {target_dir}/debug/main {raytracer_cg_llvm}",
         manifest_path = manifest_path.display(),
         target_dir = target_dir.display(),
     );


### PR DESCRIPTION
Fixes one half of rust-lang/rustc_codegen_cranelift#1686

Job was failing due to a deprecated error:

```
error: use of deprecated constant `std::f64::INFINITY`: replaced by the `INFINITY` associated constant on `f64`
  --> src/ray.rs:24:38
   |
24 |         let mut distance = std::f64::INFINITY;
   |                                      ^^^^^^^^
   |
   = note: `-D deprecated` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(deprecated)]`
```