### PR TITLE
Remove LD_STATIC_TLS_EXTRA workaround from FreeBSD CI

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -34,8 +34,5 @@ jobs:
             # Disabling incr comp reduces cache size and incr comp doesn't save
             # as much on CI anyway.
             export CARGO_BUILD_INCREMENTAL=false
-            # FIXME(rust-lang/rust#134863) necessary to avoid error when
-            # dlopening proc macros during compilation of cg_clif.
-            export LD_STATIC_TLS_EXTRA=4096
             # Skip rand as it fails on FreeBSD due to rust-random/rand#1355
             ./y.sh test --skip-test test.rust-random/rand

--- a/Readme.md
+++ b/Readme.md
@@ -66,7 +66,7 @@ For more docs on how to build and test see [build_system/usage.txt](build_system
 |OS \ architecture|x86\_64|AArch64|Riscv64|s390x (System-Z)|
 |---|---|---|---|---|
 |Linux|✅|✅|✅[^no-rustup]|✅[^no-rustup]|
-|FreeBSD|✅[^no-rustup][^tls]|❓|❓|❓|
+|FreeBSD|✅[^no-rustup]|❓|❓|❓|
 |AIX|❌[^xcoff]|N/A|N/A|❌[^xcoff]|
 |Other unixes|❓|❓|❓|❓|
 |macOS|✅|✅|N/A|N/A|
@@ -80,7 +80,6 @@ Not all targets are available as rustup component for nightly. See notes in the 
 
 [^xcoff]: XCOFF object file format is not supported.
 [^no-rustup]: Not available as [rustup component for nightly](https://rust-lang.github.io/rustup-components-history/). You can build it yourself.
-[^tls]: FreeBSD requires setting `LD_STATIC_TLS_EXTRA=4096` to build cg_clif. In addition you need at least FreeBSD 14.
 
 ## Usage
 


### PR DESCRIPTION
Fixes rust-lang/rustc_codegen_cranelift#1685

Test plan

- [x] FreeBSD CI passes without LD_STATIC_TLS_EXTRA