### PR TITLE
avoid ICE on conflicting TLS declarations

### DIFF
--- a/build_system/tests.rs
+++ b/build_system/tests.rs
@@ -106,6 +106,47 @@ const BASE_SYSROOT_SUITE: &[TestCase] = &[
             "expected graceful error, not ICE:\n{combined}"
         );
     }),
+    TestCase::custom("aot.tls_conflicting_declarations", &|runner| {
+        for (variant, expected_success) in
+            [("plain", false), ("matching", true), ("reverse", false)]
+        {
+            let mut cmd = runner.rustc_command([
+                "example/tls-conflicting-declarations.rs",
+                "--emit=obj",
+                "--check-cfg=cfg(matching)",
+                "--check-cfg=cfg(reverse)",
+            ]);
+            if variant != "plain" {
+                cmd.arg("--cfg").arg(variant);
+            }
+
+            let output = cmd.output().unwrap();
+            let combined = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+
+            assert_eq!(
+                output.status.success(),
+                expected_success,
+                "{variant}: unexpected compiler result:\n{combined}"
+            );
+            if !expected_success {
+                assert!(
+                    combined.contains(
+                        "conflicting thread-local and non-thread-local declarations for `EXPORTED`"
+                    ),
+                    "{variant}: missing conflict diagnostic:\n{combined}"
+                );
+                assert!(
+                    !combined.contains("internal compiler error")
+                        && !combined.contains("panicked at"),
+                    "{variant}: compiler ICE'd:\n{combined}"
+                );
+            }
+        }
+    }),
     TestCase::build_bin_and_run("aot.issue-72793", "example/issue-72793.rs", &[]),
     TestCase::build_bin("aot.issue-59326", "example/issue-59326.rs"),
     TestCase::build_bin_and_run("aot.neon", "example/neon.rs", &[]),

--- a/build_system/tests.rs
+++ b/build_system/tests.rs
@@ -107,9 +107,13 @@ const BASE_SYSROOT_SUITE: &[TestCase] = &[
         );
     }),
     TestCase::custom("aot.tls_conflicting_declarations", &|runner| {
-        for (variant, expected_success) in
-            [("plain", false), ("matching", true), ("reverse", false)]
-        {
+        let variants: &[(&str, bool)] = if runner.target_compiler.target.contains("windows") {
+            // Matching TLS declarations currently produce a duplicate-symbol error on Windows.
+            &[("plain", false)]
+        } else {
+            &[("plain", false), ("matching", true), ("reverse", false)]
+        };
+        for &(variant, expected_success) in variants {
             let mut cmd = runner.rustc_command([
                 "example/tls-conflicting-declarations.rs",
                 "--emit=obj",
@@ -336,6 +340,12 @@ pub(crate) fn run_tests(
     rustup_toolchain_name: Option<&str>,
     target_tuple: String,
 ) {
+    let mut skip_tests = skip_tests.to_vec();
+    // This test checks a cg_clif diagnostic; LLVM accepts the conflicting declarations.
+    if matches!(cg_clif_dylib, CodegenBackend::Builtin(name) if name == "llvm") {
+        skip_tests.push("aot.tls_conflicting_declarations");
+    }
+
     let stdlib_source =
         get_default_sysroot(&bootstrap_host_compiler.rustc).join("lib/rustlib/src/rust");
     assert!(stdlib_source.exists());
@@ -355,7 +365,7 @@ pub(crate) fn run_tests(
             target_compiler,
             use_unstable_features,
             sysroot_config.panic_unwind_support,
-            skip_tests,
+            &skip_tests,
             bootstrap_host_compiler.target == target_tuple,
             stdlib_source.clone(),
         );
@@ -388,7 +398,7 @@ pub(crate) fn run_tests(
             target_compiler,
             use_unstable_features,
             sysroot_config.panic_unwind_support,
-            skip_tests,
+            &skip_tests,
             bootstrap_host_compiler.target == target_tuple,
             stdlib_source,
         );

--- a/config.txt
+++ b/config.txt
@@ -20,6 +20,7 @@ aot.subslice-patterns-const-eval
 aot.track-caller-attribute
 aot.float-minmax-pass
 aot.powi_libcall_signature
+aot.tls_conflicting_declarations
 aot.issue-72793
 aot.issue-59326
 aot.neon

--- a/example/tls-conflicting-declarations.rs
+++ b/example/tls-conflicting-declarations.rs
@@ -1,0 +1,15 @@
+#![feature(thread_local)]
+
+#[cfg_attr(any(matching, reverse), thread_local)]
+#[unsafe(no_mangle)]
+static EXPORTED: u64 = 0;
+
+unsafe extern "C" {
+    #[cfg_attr(not(reverse), thread_local)]
+    #[link_name = "EXPORTED"]
+    static C: u64;
+}
+
+fn main() {
+    unsafe { C };
+}

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -281,6 +281,18 @@ fn data_id_for_static(
     let instance = Instance::mono(tcx, def_id);
     let symbol_name = tcx.symbol_name(instance).name;
 
+    let is_thread_local = attrs.flags.contains(CodegenFnAttrFlags::THREAD_LOCAL);
+    if let Some(FuncOrDataId::Data(existing_id)) = module.get_name(symbol_name)
+        && module.declarations().get_data_decl(existing_id).tls != is_thread_local
+    {
+        tcx.dcx().span_fatal(
+            tcx.def_span(def_id),
+            format!(
+                "conflicting thread-local and non-thread-local declarations for `{symbol_name}`"
+            ),
+        );
+    }
+
     if let Some(import_linkage) = attrs.import_linkage {
         assert!(!definition);
         assert!(!tcx.is_mutable_static(def_id));
@@ -305,7 +317,7 @@ fn data_id_for_static(
             symbol_name,
             linkage,
             false,
-            attrs.flags.contains(CodegenFnAttrFlags::THREAD_LOCAL),
+            is_thread_local,
         ) {
             Ok(data_id) => data_id,
             Err(ModuleError::IncompatibleDeclaration(_)) => tcx.dcx().fatal(format!(
@@ -356,7 +368,7 @@ fn data_id_for_static(
         symbol_name,
         linkage,
         definition_writable,
-        attrs.flags.contains(CodegenFnAttrFlags::THREAD_LOCAL),
+        is_thread_local,
     ) {
         Ok(data_id) => data_id,
         Err(ModuleError::IncompatibleDeclaration(_)) => tcx.dcx().fatal(format!(

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -364,12 +364,7 @@ fn data_id_for_static(
         Linkage::Import
     };
 
-    match module.declare_data(
-        symbol_name,
-        linkage,
-        definition_writable,
-        is_thread_local,
-    ) {
+    match module.declare_data(symbol_name, linkage, definition_writable, is_thread_local) {
         Ok(data_id) => data_id,
         Err(ModuleError::IncompatibleDeclaration(_)) => tcx.dcx().fatal(format!(
             "attempt to declare `{symbol_name}` as static, but it was already declared as function"


### PR DESCRIPTION
fixes rust-lang/rustc_codegen_cranelift#1691

declaring the same symbol as both thread-local and non-thread-local currently makes cg_clif ICE when Cranelift tries to merge the declarations.

we can check for the mismatch first and reports a compiler error instead